### PR TITLE
large file exporter fix

### DIFF
--- a/src/exporter.js
+++ b/src/exporter.js
@@ -58,7 +58,6 @@ function exporter (hash, dagService, options, callback) {
       }
       return
     } else {
-      ee.emit('file', { stream: rs, path: name, dir: dir })
       init = false
       rs._read = () => {
         if (init) {
@@ -88,6 +87,7 @@ function exporter (hash, dagService, options, callback) {
           return
         })
       }
+      ee.emit('file', { stream: rs, path: name, dir: dir })
     }
   }
 


### PR DESCRIPTION
the event emitter for files with links needed to be moved to after the stream pushed its first chunk of data to the stream