### PR TITLE
End export stream on completion.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "block-stream2": "^1.1.0",
     "bs58": "^3.0.0",
     "debug": "^2.2.0",
-    "field-trip": "0.0.2",
+    "field-trip": "0.0.3",
     "ipfs-merkle-dag": "^0.5.0",
     "ipfs-unixfs": "^0.1.0",
     "is-ipfs": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,12 @@
   "homepage": "https://github.com/diasdavid/js-ipfs-data-importing#readme",
   "devDependencies": {
     "aegir": "^3.0.1",
+    "async": "^1.5.2",
     "block-stream2": "^1.1.0",
     "bs58": "^3.0.0",
     "buffer-loader": "0.0.1",
     "chai": "^3.5.0",
+    "concat-stream": "^1.5.1",
     "fs-blob-store": "^5.2.1",
     "idb-plus-blob-store": "^1.1.2",
     "ipfs-repo": "^0.7.5",
@@ -51,9 +53,9 @@
     "string-to-stream": "^1.0.1"
   },
   "dependencies": {
-    "async": "^1.5.2",
     "block-stream2": "^1.1.0",
     "debug": "^2.2.0",
+    "field-trip": "0.0.2",
     "ipfs-merkle-dag": "^0.5.0",
     "ipfs-unixfs": "^0.1.0",
     "isstream": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -54,10 +54,12 @@
   },
   "dependencies": {
     "block-stream2": "^1.1.0",
+    "bs58": "^3.0.0",
     "debug": "^2.2.0",
     "field-trip": "0.0.2",
     "ipfs-merkle-dag": "^0.5.0",
     "ipfs-unixfs": "^0.1.0",
+    "is-ipfs": "^0.2.0",
     "isstream": "^0.1.2",
     "readable-stream": "^1.1.13",
     "run-series": "^1.1.4",

--- a/src/exporter.js
+++ b/src/exporter.js
@@ -36,7 +36,7 @@ function Exporter (hash, dagService, options) {
   this._read = (n) => {}
 
   let fileExporter = (node, name, done) => {
-    let init
+    let init = false
 
     if (!done) throw new Error('done must be set')
 
@@ -44,7 +44,6 @@ function Exporter (hash, dagService, options) {
     var rs = new Readable()
     if (node.links.length === 0) {
       const unmarshaledData = UnixFS.unmarshal(node.data)
-      init = false
       rs._read = () => {
         if (init) {
           return
@@ -56,7 +55,6 @@ function Exporter (hash, dagService, options) {
       this.push({ content: rs, path: name })
       done()
     } else {
-      init = false
       rs._read = () => {
         if (init) {
           return

--- a/src/exporter.js
+++ b/src/exporter.js
@@ -3,6 +3,8 @@
 const debug = require('debug')
 const log = debug('exporter')
 log.err = debug('exporter:error')
+const isIPFS = require('is-ipfs')
+const bs58 = require('bs58')
 const UnixFS = require('ipfs-unixfs')
 const series = require('run-series')
 const Readable = require('readable-stream').Readable
@@ -17,6 +19,14 @@ util.inherits(Exporter, Readable)
 function Exporter (hash, dagService, options) {
   if (!(this instanceof Exporter)) {
     return new Exporter(hash, dagService, options)
+  }
+
+  // Sanitize hash.
+  if (!isIPFS.multihash(hash)) {
+    throw new Error('not valid multihash')
+  }
+  if (Buffer.isBuffer(hash)) {
+    hash = bs58.encode(hash)
   }
 
   Readable.call(this, { objectMode: true })

--- a/src/exporter.js
+++ b/src/exporter.js
@@ -5,10 +5,10 @@ const log = debug('exporter')
 log.err = debug('exporter:error')
 const UnixFS = require('ipfs-unixfs')
 const series = require('run-series')
-const async = require('async')
 const Readable = require('readable-stream').Readable
 const pathj = require('path')
 const util = require('util')
+const fieldtrip = require('field-trip')
 
 exports = module.exports = Exporter
 
@@ -25,11 +25,12 @@ function Exporter (hash, dagService, options) {
 
   this._read = (n) => {}
 
-  let fileExporter = (node, name, callback) => {
+  let fileExporter = (node, name, done) => {
     let init
 
-    if (!callback) { callback = function noop () {} }
+    if (!done) throw new Error('done must be set')
 
+    // Logic to export a single (possibly chunked) unixfs file.
     var rs = new Readable()
     if (node.links.length === 0) {
       const unmarshaledData = UnixFS.unmarshal(node.data)
@@ -43,8 +44,7 @@ function Exporter (hash, dagService, options) {
         rs.push(null)
       }
       this.push({ content: rs, path: name })
-      callback()
-      return
+      done()
     } else {
       init = false
       rs._read = () => {
@@ -57,7 +57,7 @@ function Exporter (hash, dagService, options) {
           return (cb) => {
             dagService.get(link.hash, (err, res) => {
               if (err) {
-                cb(err)
+                return cb(err)
               }
               var unmarshaledData = UnixFS.unmarshal(res.data)
               rs.push(unmarshaledData.data)
@@ -67,26 +67,28 @@ function Exporter (hash, dagService, options) {
         })
         series(array, (err, res) => {
           if (err) {
-            callback()
+            rs.emit('error', err)
             return
           }
           rs.push(null)
-          callback()
           return
         })
       }
       this.push({ content: rs, path: name })
-      callback()
-      return
+      done()
     }
   }
 
-  let dirExporter = (node, name, callback) => {
+  // Logic to export a unixfs directory.
+  let dirExporter = (node, name, add, done) => {
     let init
 
-    if (!callback) { callback = function noop () {} }
+    if (!add) throw new Error('add must be set')
+    if (!done) throw new Error('done must be set')
 
     var rs = new Readable()
+
+    // Directory has no links
     if (node.links.length === 0) {
       init = false
       rs._read = () => {
@@ -98,49 +100,45 @@ function Exporter (hash, dagService, options) {
         rs.push(null)
       }
       this.push({content: null, path: name})
-      callback()
-      return
+      done()
     } else {
-      async.forEachSeries(node.links, (link, callback) => {
-        dagService.get(link.hash, (err, res) => {
-          if (err) {
-            callback(err)
-          }
-          var unmarshaledData = UnixFS.unmarshal(res.data)
-          if (unmarshaledData.type === 'file') {
-            return (fileExporter(res, pathj.join(name, link.name), callback))
-          }
-          if (unmarshaledData.type === 'directory') {
-            return (dirExporter(res, pathj.join(name, link.name), callback))
-          }
-          callback()
-        })
-      }, (err) => {
-        if (err) {
-          callback()
-          return
-        }
-        callback()
-        return
+      node.links.forEach((link) => {
+        add({ path: pathj.join(name, link.name), hash: link.hash })
       })
+      done()
     }
   }
 
-  dagService.get(hash, (err, fetchedNode) => {
+  // Traverse the DAG asynchronously
+  var self = this
+  fieldtrip([{ path: hash, hash: hash }], visit, (err) => {
     if (err) {
-      this.emit('error', err)
+      self.emit('error', err)
       return
     }
-    const data = UnixFS.unmarshal(fetchedNode.data)
-    const type = data.type
-
-    if (type === 'directory') {
-      dirExporter(fetchedNode, hash)
-    }
-    if (type === 'file') {
-      fileExporter(fetchedNode, hash)
-    }
+    self.push(null)
   })
+
+  // Visit function: called once per node in the exported graph
+  function visit (item, add, done) {
+    dagService.get(item.hash, (err, fetchedNode) => {
+      if (err) {
+        self.emit('error', err)
+        return
+      }
+
+      const data = UnixFS.unmarshal(fetchedNode.data)
+      const type = data.type
+
+      if (type === 'directory') {
+        dirExporter(fetchedNode, item.path, add, done)
+      }
+
+      if (type === 'file') {
+        fileExporter(fetchedNode, item.path, done)
+      }
+    })
+  }
 
   return this
 }

--- a/src/exporter.js
+++ b/src/exporter.js
@@ -91,32 +91,18 @@ function Exporter (hash, dagService, options) {
 
   // Logic to export a unixfs directory.
   let dirExporter = (node, name, add, done) => {
-    let init
-
     if (!add) throw new Error('add must be set')
     if (!done) throw new Error('done must be set')
 
-    var rs = new Readable()
+    this.push({content: null, path: name})
 
-    // Directory has no links
-    if (node.links.length === 0) {
-      init = false
-      rs._read = () => {
-        if (init) {
-          return
-        }
-        init = true
-        rs.push(node.data)
-        rs.push(null)
-      }
-      this.push({content: null, path: name})
-      done()
-    } else {
+    // Directory has links
+    if (node.links.length > 0) {
       node.links.forEach((link) => {
         add({ path: pathj.join(name, link.name), hash: link.hash })
       })
-      done()
     }
+    done()
   }
 
   // Traverse the DAG asynchronously

--- a/test/test-exporter.js
+++ b/test/test-exporter.js
@@ -87,10 +87,12 @@ module.exports = function (repo) {
         expect(err).to.not.exist
       })
       testExport.pipe(concat((files) => {
-        expect(files[0].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/200Bytes.txt')
-        expect(files[1].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/dir-another')
-        expect(files[2].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/level-1/200Bytes.txt')
-        expect(files[3].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/level-1/level-2')
+        expect(files[0].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN')
+        expect(files[1].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/200Bytes.txt')
+        expect(files[2].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/dir-another')
+        expect(files[3].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/level-1')
+        expect(files[4].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/level-1/200Bytes.txt')
+        expect(files[5].path).to.equal('QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/level-1/level-2')
         done()
       }))
     })


### PR DESCRIPTION
I noticed that the Exporter stream doesn't actually end. This PR fixes that and also adds tests that removes this assumption, and also some timing assumptions. It also cleans up the overall DAG traversal logic.

I also switched us over to `concat-stream` from `bl`, just because the former handles object streams nicely too.