### PR TITLE
Adds call to progress bar function

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The input's file paths and directory structure will be preserved in the [`dag-pb
 - `dirBuilder` (object): the options for the directory builder
   - `hamt` (object): the options for the HAMT sharded directory builder
     - bits (positive integer, defaults to `8`): the number of bits at each bucket of the HAMT
+- `progress` (function): a function that will be called with the byte length of chunks as a file is added to ipfs.
 
 ### Exporter
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "pull-generate": "^2.2.0",
     "pull-zip": "^2.0.1",
     "rimraf": "^2.6.1",
+    "sinon": "^3.2.1",
     "split": "^1.0.0"
   },
   "dependencies": {

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -93,7 +93,10 @@ module.exports = function (createChunker, ipldResolver, createReducer, _options)
     pull(
       file.content,
       createChunker(options.chunkerOptions),
-      pull.map(chunk => new Buffer(chunk)),
+      pull.map(chunk => {
+        if (options.progress) options.progress(chunk.byteLength)
+        return new Buffer(chunk)
+      }),
       pull.map(buffer => new UnixFS('file', buffer)),
       pull.asyncMap((fileNode, callback) => {
         DAGNode.create(fileNode.marshal(), (err, node) => {

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -94,7 +94,9 @@ module.exports = function (createChunker, ipldResolver, createReducer, _options)
       file.content,
       createChunker(options.chunkerOptions),
       pull.map(chunk => {
-        if (options.progress) options.progress(chunk.byteLength)
+        if (options.progress && typeof options.progress === 'function') {
+          options.progress(chunk.byteLength)
+        }
         return new Buffer(chunk)
       }),
       pull.map(buffer => new UnixFS('file', buffer)),

--- a/test/test-importer.js
+++ b/test/test-importer.js
@@ -428,7 +428,7 @@ module.exports = (repo) => {
           }]),
           importer(ipldResolver, options),
           pull.collect(() => {
-            expect(options.progress.called).to.be.true
+            expect(options.progress.called).to.equal(true)
             expect(options.progress.args[0][0]).to.equal(1024)
             done()
           })
@@ -444,7 +444,7 @@ module.exports = (repo) => {
           }]),
           importer(ipldResolver, options),
           pull.collect(() => {
-            expect(options.progress.notCalled).to.be.true
+            expect(options.progress.notCalled).to.equal(true)
             done()
           })
         )

--- a/test/test-importer.js
+++ b/test/test-importer.js
@@ -419,8 +419,9 @@ module.exports = (repo) => {
         }
       })
 
-      it('will call a progress function', (done) => {
+      it('will call an optional progress function', (done) => {
         options.progress = sinon.spy()
+
         pull(
           pull.values([{
             path: '1.2MiB.txt',
@@ -430,21 +431,6 @@ module.exports = (repo) => {
           pull.collect(() => {
             expect(options.progress.called).to.equal(true)
             expect(options.progress.args[0][0]).to.equal(1024)
-            done()
-          })
-        )
-      })
-
-      it('only if it is passed', (done) => {
-        options.progress = false
-        pull(
-          pull.values([{
-            path: '200Bytes.txt',
-            content: pull.values([smallFile])
-          }]),
-          importer(ipldResolver, options),
-          pull.collect(() => {
-            expect(options.progress.notCalled).to.equal(true)
             done()
           })
         )


### PR DESCRIPTION
This change adds a call to an optional function that can be passed to `Importer`.
This will be called with the byte length of a file's buffered chunk.

The idea is you can pass a function into the Importer and have that function called as a step in the pull stream that creates and stores a file/files.