### PR TITLE
Specify hash algorithm when creating nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ipld-resolver": "^0.13.0",
     "left-pad": "^1.1.3",
     "lodash": "^4.17.4",
-    "multihashes": "^0.4.5",
+    "multihashes": "^0.4.9",
     "multihashing-async": "^0.4.6",
     "pull-batch": "^1.0.0",
     "pull-block": "^1.2.0",

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -58,7 +58,7 @@ module.exports = function (createChunker, ipldResolver, createReducer, _options)
 
     const d = new UnixFS('directory')
     waterfall([
-      (cb) => DAGNode.create(d.marshal(), cb),
+      (cb) => DAGNode.create(d.marshal(), [], options.hashAlg, cb),
       (node, cb) => {
         ipldResolver.put(node, {
           cid: new CID(node.multihash)
@@ -96,7 +96,7 @@ module.exports = function (createChunker, ipldResolver, createReducer, _options)
       pull.map(chunk => new Buffer(chunk)),
       pull.map(buffer => new UnixFS('file', buffer)),
       pull.asyncMap((fileNode, callback) => {
-        DAGNode.create(fileNode.marshal(), (err, node) => {
+        DAGNode.create(fileNode.marshal(), [], options.hashAlg, (err, node) => {
           callback(err, { DAGNode: node, fileNode: fileNode })
         })
       }),

--- a/test/browser.js
+++ b/test/browser.js
@@ -34,6 +34,7 @@ describe('IPFS data importing tests on the Browser', function () {
     ], done)
   })
 
+  require('./test-builder')(repo)
   require('./test-flat-builder')
   require('./test-balanced-builder')
   require('./test-trickle-builder')

--- a/test/node.js
+++ b/test/node.js
@@ -36,6 +36,7 @@ describe('IPFS UnixFS Engine', () => {
     ], done)
   })
 
+  require('./test-builder')(repo)
   require('./test-flat-builder')
   require('./test-balanced-builder')
   require('./test-trickle-builder')

--- a/test/test-builder.js
+++ b/test/test-builder.js
@@ -1,0 +1,45 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const BlockService = require('ipfs-block-service')
+const pull = require('pull-stream')
+const mh = require('multihashes')
+const IPLDResolver = require('ipld-resolver')
+const eachSeries = require('async').eachSeries
+const createBuilder = require('../src/builder')
+const FixedSizeChunker = require('../src/chunker/fixed-size')
+
+module.exports = (repo) => {
+  describe('builder', () => {
+    let ipldResolver
+
+    before(() => {
+      const bs = new BlockService(repo)
+      ipldResolver = new IPLDResolver(bs)
+    })
+
+    it('allows multihash hash algorithm to be specified', (done) => {
+      eachSeries(Object.keys(mh.names), (hashAlg, cb) => {
+        const options = { hashAlg, strategy: 'flat' }
+        const content = String(Math.random() + Date.now())
+
+        pull(
+          pull.values([{
+            path: content + '.txt',
+            content: Buffer.from(content)
+          }]),
+          createBuilder(FixedSizeChunker, ipldResolver, options),
+          pull.collect((err, nodes) => {
+            expect(err).to.not.exist()
+            expect(nodes.length).to.equal(1)
+            expect(mh.decode(nodes[0].multihash).name).to.equal(hashAlg)
+            cb(err)
+          })
+        )
+      }, done)
+    })
+  })
+}


### PR DESCRIPTION
Simply pass through the `hashAlg` option to `DAGNode.create`.