### PR TITLE
Fix the test

### DIFF
--- a/test/test-builder.js
+++ b/test/test-builder.js
@@ -51,7 +51,7 @@ module.exports = (repo) => {
         }
 
         pull(
-          pull.values([inputFile]),
+          pull.values([Object.assign({}, inputFile)]),
           createBuilder(FixedSizeChunker, ipldResolver, options),
           pull.collect(onCollected)
         )


### PR DESCRIPTION
The builder mutates the params you give it so you can no longer use the original to compare with the output.

The fix was to clone the input before passing to the builder. I would argue that it's mildly unexpected for the builder to mutate the input objects...perhaps the builder should be taking a clone of the inputs for it's own purposes? One for another PR?

Also, sorry sorry sorry - never change things after you run the tests and think "it'll be fine".

fixes #181
