### PR TITLE
Allow specify hash algorithm for large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The `import` object is a duplex pull stream that takes objects of the form:
 }
 ```
 
-`import` will outoyt file info objects as files get stored in IPFS. When stats on a node are emitted they are guaranteed to have been written.
+`import` will output file info objects as files get stored in IPFS. When stats on a node are emitted they are guaranteed to have been written.
 
 `dag` is an instance of the [`IPLD Resolver`](https://github.com/ipld/js-ipld-resolver) or the [`js-ipfs` `dag api`](https://github.com/ipfs/interface-ipfs-core/tree/master/API/dag)
 
@@ -140,6 +140,7 @@ The input's file paths and directory structure will be preserved in the [`dag-pb
     - bits (positive integer, defaults to `8`): the number of bits at each bucket of the HAMT
 - `progress` (function): a function that will be called with the byte length of chunks as a file is added to ipfs.
 - `onlyHash` (boolean, defaults to false): Only chunk and hash - do not write to disk
+- `hashAlg` (string): multihash hashing algorithm to use
 
 ### Exporter
 

--- a/src/builder/reduce.js
+++ b/src/builder/reduce.js
@@ -32,7 +32,7 @@ module.exports = function (file, ipldResolver, options) {
     })
 
     waterfall([
-      (cb) => DAGNode.create(f.marshal(), links, cb),
+      (cb) => DAGNode.create(f.marshal(), links, options.hashAlg, cb),
       (node, cb) => {
         if (options.onlyHash) return cb(null, node)
 

--- a/src/importer/dir-flat.js
+++ b/src/importer/dir-flat.js
@@ -56,12 +56,13 @@ class DirFlat extends Dir {
       })
 
     const dir = new UnixFS('directory')
+    const options = this._options
 
     waterfall(
       [
-        (callback) => DAGNode.create(dir.marshal(), links, callback),
+        (callback) => DAGNode.create(dir.marshal(), links, options.hashAlg, callback),
         (node, callback) => {
-          if (this._options.onlyHash) return callback(null, node)
+          if (options.onlyHash) return callback(null, node)
 
           ipldResolver.put(
             node,

--- a/src/importer/dir-sharded.js
+++ b/src/importer/dir-sharded.js
@@ -144,7 +144,7 @@ function flush (options, bucket, path, ipldResolver, source, callback) {
     dir.hashType = options.hashFn.code
     waterfall(
       [
-        (callback) => DAGNode.create(dir.marshal(), links, callback),
+        (callback) => DAGNode.create(dir.marshal(), links, options.hashAlg, callback),
         (node, callback) => {
           if (options.onlyHash) return callback(null, node)
 


### PR DESCRIPTION
I realised I hadn't propagated the `hashAlg` option to all the places where it was needed. Added test also.