### PR TITLE
Use passed CID version option when writing to storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The input's file paths and directory structure will be preserved in the [`dag-pb
 - `progress` (function): a function that will be called with the byte length of chunks as a file is added to ipfs.
 - `onlyHash` (boolean, defaults to false): Only chunk and hash - do not write to disk
 - `hashAlg` (string): multihash hashing algorithm to use
+- `cidVersion` (integer, default 0): the CID version to use when storing the data (storage keys are based on the CID, _including_ it's version)
 
 ### Exporter
 

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -63,9 +63,13 @@ module.exports = function (createChunker, ipldResolver, createReducer, _options)
       (node, cb) => {
         if (options.onlyHash) return cb(null, node)
 
-        ipldResolver.put(node, {
-          cid: new CID(node.multihash)
-        }, (err) => cb(err, node))
+        let cid = new CID(node.multihash)
+
+        if (options.cidVersion === 1) {
+          cid = cid.toV1()
+        }
+
+        ipldResolver.put(node, { cid }, (err) => cb(err, node))
       }
     ], (err, node) => {
       if (err) {
@@ -111,10 +115,13 @@ module.exports = function (createChunker, ipldResolver, createReducer, _options)
       pull.asyncMap((leaf, callback) => {
         if (options.onlyHash) return callback(null, leaf)
 
-        ipldResolver.put(leaf.DAGNode, {
-          cid: new CID(leaf.DAGNode.multihash)
-        }, (err) => callback(err, leaf)
-        )
+        let cid = new CID(leaf.DAGNode.multihash)
+
+        if (options.cidVersion === 1) {
+          cid = cid.toV1()
+        }
+
+        ipldResolver.put(leaf.DAGNode, { cid }, (err) => callback(err, leaf))
       }),
       pull.map((leaf) => {
         return {

--- a/src/builder/reduce.js
+++ b/src/builder/reduce.js
@@ -36,9 +36,13 @@ module.exports = function (file, ipldResolver, options) {
       (node, cb) => {
         if (options.onlyHash) return cb(null, node)
 
-        ipldResolver.put(node, {
-          cid: new CID(node.multihash)
-        }, (err) => cb(err, node))
+        let cid = new CID(node.multihash)
+
+        if (options.cidVersion === 1) {
+          cid = cid.toV1()
+        }
+
+        ipldResolver.put(node, { cid }, (err) => cb(err, node))
       }
     ], (err, node) => {
       if (err) {

--- a/src/importer/dir-flat.js
+++ b/src/importer/dir-flat.js
@@ -64,12 +64,13 @@ class DirFlat extends Dir {
         (node, callback) => {
           if (options.onlyHash) return callback(null, node)
 
-          ipldResolver.put(
-            node,
-            {
-              cid: new CID(node.multihash)
-            },
-            (err) => callback(err, node))
+          let cid = new CID(node.multihash)
+
+          if (options.cidVersion === 1) {
+            cid = cid.toV1()
+          }
+
+          ipldResolver.put(node, { cid }, (err) => callback(err, node))
         },
         (node, callback) => {
           this.multihash = node.multihash

--- a/src/importer/dir-sharded.js
+++ b/src/importer/dir-sharded.js
@@ -148,12 +148,13 @@ function flush (options, bucket, path, ipldResolver, source, callback) {
         (node, callback) => {
           if (options.onlyHash) return callback(null, node)
 
-          ipldResolver.put(
-            node,
-            {
-              cid: new CID(node.multihash)
-            },
-            (err) => callback(err, node))
+          let cid = new CID(node.multihash)
+
+          if (options.cidVersion === 1) {
+            cid = cid.toV1()
+          }
+
+          ipldResolver.put(node, { cid }, (err) => callback(err, node))
         },
         (node, callback) => {
           const pushable = {


### PR DESCRIPTION
Necessary because:

If I put an object using a CIDv0 with the ipld resolver I have to retrieve it using a CIDv0, I can’t use CIDv1, even if the multihash and the codec are the same.

This is because the key for the data in the repo is derived from `CID.buffer`

See https://github.com/ipld/js-cid/blob/master/src/index.js#L115-L128
And https://github.com/ipfs/js-ipfs-repo/blob/master/src/blockstore.js#L29-L31