### PR TITLE
Testing latest pull-block

### DIFF
--- a/test/hamt.js
+++ b/test/hamt.js
@@ -97,7 +97,7 @@ describe('HAMT', () => {
     })
 
     it('can remove all the keys and still find remaining', function (done) {
-      this.timeout(50 * 1000)
+      this.timeout(30 * 1000)
 
       masterHead = keys.pop()
       iterate()


### PR DESCRIPTION
ref: https://github.com/dignifiedquire/pull-block/pull/10

I was trying to see if the latest pull-block only failed in one edge case (of feeding bytes very slowly to the) or if it failed in more. It happens that there are multiple tests that fail here until https://github.com/dignifiedquire/pull-block/pull/10

Will wait until https://github.com/dignifiedquire/pull-block/pull/10 is finished to release this one with confidence. 