### PR TITLE
exporter maxDepth

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "pull-batch": "^1.0.0",
     "pull-block": "1.2.0",
     "pull-cat": "^1.1.11",
-    "pull-defer": "~0.2.2",
     "pull-pair": "^1.1.0",
     "pull-paramap": "^1.2.2",
     "pull-pause": "0.0.1",

--- a/src/exporter/dir-flat.js
+++ b/src/exporter/dir-flat.js
@@ -6,7 +6,7 @@ const cat = require('pull-cat')
 // Logic to export a unixfs directory.
 module.exports = dirExporter
 
-function dirExporter (node, name, path, pathRest, resolve, dag, parent, depth) {
+function dirExporter (node, name, path, pathRest, resolve, size, dag, parent, depth) {
   const accepts = pathRest[0]
 
   const dir = {

--- a/src/exporter/dir-flat.js
+++ b/src/exporter/dir-flat.js
@@ -1,17 +1,16 @@
 'use strict'
 
 const pull = require('pull-stream')
-const CID = require('cids')
 const cat = require('pull-cat')
 
 // Logic to export a unixfs directory.
 module.exports = dirExporter
 
-function dirExporter (node, name, pathRest, resolve) {
+function dirExporter (node, path, pathRest, resolve) {
   const accepts = pathRest[0]
 
   const dir = {
-    path: name,
+    path: path,
     hash: node.multihash
   }
 
@@ -19,7 +18,9 @@ function dirExporter (node, name, pathRest, resolve) {
     pull(
       pull.values(node.links),
       pull.map((link) => ({
-        path: name + '/' + link.name,
+        size: link.size,
+        name: link.name,
+        path: path + '/' + link.name,
         multihash: link.multihash,
         linkName: link.name,
         pathRest: pathRest.slice(1)

--- a/src/exporter/dir-flat.js
+++ b/src/exporter/dir-flat.js
@@ -6,24 +6,29 @@ const cat = require('pull-cat')
 // Logic to export a unixfs directory.
 module.exports = dirExporter
 
-function dirExporter (node, path, pathRest, resolve) {
+function dirExporter (node, name, path, pathRest, resolve, dag, parent, depth) {
   const accepts = pathRest[0]
 
   const dir = {
+    name: name,
+    depth: depth,
     path: path,
-    hash: node.multihash
+    hash: node.multihash,
+    type: 'dir'
   }
 
   const streams = [
     pull(
       pull.values(node.links),
       pull.map((link) => ({
+        depth: depth + 1,
         size: link.size,
         name: link.name,
         path: path + '/' + link.name,
         multihash: link.multihash,
         linkName: link.name,
-        pathRest: pathRest.slice(1)
+        pathRest: pathRest.slice(1),
+        type: 'dir'
       })),
       pull.filter((item) => accepts === undefined || item.linkName === accepts),
       resolve

--- a/src/exporter/dir-flat.js
+++ b/src/exporter/dir-flat.js
@@ -14,6 +14,7 @@ function dirExporter (node, name, path, pathRest, resolve, dag, parent, depth) {
     depth: depth,
     path: path,
     hash: node.multihash,
+    size: node.size,
     type: 'dir'
   }
 

--- a/src/exporter/dir-hamt-sharded.js
+++ b/src/exporter/dir-hamt-sharded.js
@@ -1,18 +1,17 @@
 'use strict'
 
 const pull = require('pull-stream')
-const CID = require('cids')
 const cat = require('pull-cat')
 const cleanHash = require('./clean-multihash')
 
 // Logic to export a unixfs directory.
 module.exports = shardedDirExporter
 
-function shardedDirExporter (node, name, pathRest, resolve, dag, parent) {
+function shardedDirExporter (node, path, pathRest, resolve, dag, parent) {
   let dir
-  if (!parent || parent.path !== name) {
+  if (!parent || parent.path !== path) {
     dir = [{
-      path: name,
+      path: path,
       hash: cleanHash(node.multihash)
     }]
   }
@@ -23,7 +22,7 @@ function shardedDirExporter (node, name, pathRest, resolve, dag, parent) {
       pull.map((link) => {
         // remove the link prefix (2 chars for the bucket index)
         const p = link.name.substring(2)
-        const pp = p ? name + '/' + p : name
+        const pp = p ? path + '/' + p : path
         let accept = true
         let fromPathRest = false
 

--- a/src/exporter/dir-hamt-sharded.js
+++ b/src/exporter/dir-hamt-sharded.js
@@ -15,6 +15,7 @@ function shardedDirExporter (node, name, path, pathRest, resolve, dag, parent, d
       depth: depth,
       path: path,
       hash: cleanHash(node.multihash),
+      size: node.size,
       type: 'dir'
     }
   }

--- a/src/exporter/dir-hamt-sharded.js
+++ b/src/exporter/dir-hamt-sharded.js
@@ -7,7 +7,7 @@ const cleanHash = require('./clean-multihash')
 // Logic to export a unixfs directory.
 module.exports = shardedDirExporter
 
-function shardedDirExporter (node, name, path, pathRest, resolve, dag, parent, depth) {
+function shardedDirExporter (node, name, path, pathRest, resolve, size, dag, parent, depth) {
   let dir
   if (!parent || (parent.path !== path)) {
     dir = {

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -7,7 +7,7 @@ const pull = require('pull-stream')
 const paramap = require('pull-paramap')
 
 // Logic to export a single (possibly chunked) unixfs file.
-module.exports = (node, path, pathRest, resolve, dag) => {
+module.exports = (node, name, path, pathRest, resolve, dag, parent, depth) => {
   function getData (node) {
     try {
       const file = UnixFS.unmarshal(node.data)
@@ -38,9 +38,12 @@ module.exports = (node, path, pathRest, resolve, dag) => {
 
   const file = UnixFS.unmarshal(node.data)
   return pull.values([{
+    depth: depth,
     content: content,
+    name: name,
     path: path,
     hash: node.multihash,
-    size: file.fileSize()
+    size: file.fileSize(),
+    type: 'file'
   }])
 }

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -7,7 +7,7 @@ const pull = require('pull-stream')
 const paramap = require('pull-paramap')
 
 // Logic to export a single (possibly chunked) unixfs file.
-module.exports = (node, name, pathRest, resolve, dag) => {
+module.exports = (node, path, pathRest, resolve, dag) => {
   function getData (node) {
     try {
       const file = UnixFS.unmarshal(node.data)
@@ -27,7 +27,7 @@ module.exports = (node, name, pathRest, resolve, dag) => {
 
   const accepts = pathRest[0]
 
-  if (accepts !== undefined && accepts !== name) {
+  if (accepts !== undefined && accepts !== path) {
     return pull.empty()
   }
 
@@ -39,7 +39,7 @@ module.exports = (node, name, pathRest, resolve, dag) => {
   const file = UnixFS.unmarshal(node.data)
   return pull.values([{
     content: content,
-    path: name,
+    path: path,
     hash: node.multihash,
     size: file.fileSize()
   }])

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -7,7 +7,7 @@ const pull = require('pull-stream')
 const paramap = require('pull-paramap')
 
 // Logic to export a single (possibly chunked) unixfs file.
-module.exports = (node, name, path, pathRest, resolve, dag, parent, depth) => {
+module.exports = (node, name, path, pathRest, resolve, size, dag, parent, depth) => {
   function getData (node) {
     try {
       const file = UnixFS.unmarshal(node.data)
@@ -43,7 +43,7 @@ module.exports = (node, name, path, pathRest, resolve, dag, parent, depth) => {
     name: name,
     path: path,
     hash: node.multihash,
-    size: file.fileSize(),
+    size: size || file.fileSize(),
     type: 'file'
   }])
 }

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -7,7 +7,7 @@ const pull = require('pull-stream')
 const paramap = require('pull-paramap')
 
 // Logic to export a single (possibly chunked) unixfs file.
-module.exports = (node, name, pathRest, ipldResolver) => {
+module.exports = (node, name, pathRest, resolve, dag) => {
   function getData (node) {
     try {
       const file = UnixFS.unmarshal(node.data)
@@ -20,12 +20,12 @@ module.exports = (node, name, pathRest, ipldResolver) => {
   function visitor (node) {
     return pull(
       pull.values(node.links),
-      paramap((link, cb) => ipldResolver.get(new CID(link.multihash), cb)),
+      paramap((link, cb) => dag.get(new CID(link.multihash), cb)),
       pull.map((result) => result.value)
     )
   }
 
-  const accepts = pathRest.shift()
+  const accepts = pathRest[0]
 
   if (accepts !== undefined && accepts !== name) {
     return pull.empty()

--- a/src/exporter/index.js
+++ b/src/exporter/index.js
@@ -57,17 +57,22 @@ module.exports = (path, dag, _options) => {
       multihash: new CID(dPath.base),
       name: dPath.base,
       path: dPath.base,
-      pathRest: dPath.rest
+      pathRest: dPath.rest,
+      depth: 0
     }]),
     createResolver(dag, options),
-    pull.map((node) => ({
-      name: node.name,
-      path: finalPathFor(node),
-      size: node.size,
-      hash: node.hash || node.multihash,
-      content: node.content,
-      type: node.type
-    }))
+    pull.filter(Boolean),
+    pull.map((node) => {
+      return {
+        depth: node.depth,
+        name: node.name,
+        path: finalPathFor(node),
+        size: node.size,
+        hash: node.hash || node.multihash,
+        content: node.content,
+        type: node.type
+      }
+    })
   )
 
   function finalPathFor (node) {

--- a/src/exporter/index.js
+++ b/src/exporter/index.js
@@ -2,9 +2,9 @@
 
 const pull = require('pull-stream')
 const CID = require('cids')
-const pullDefer = require('pull-defer')
+const b58Encode = require('bs58').encode
 
-const resolve = require('./resolve').resolve
+const createResolver = require('./resolve').createResolver
 
 function pathBaseAndRest (path) {
   // Buffer -> raw multihash or CID in buffer
@@ -36,28 +36,60 @@ function pathBaseAndRest (path) {
   }
 }
 
-module.exports = (path, dag) => {
+const defaultOptions = {
+  recurse: true
+}
+
+module.exports = (path, dag, _options) => {
+
+  const options = Object.assign({}, defaultOptions, _options)
+
+  let dPath
   try {
-    path = pathBaseAndRest(path)
+    dPath = pathBaseAndRest(path)
   } catch (err) {
     return pull.error(err)
   }
 
-  const d = pullDefer.source()
-
-  const cid = new CID(path.base)
-
-  dag.get(cid, (err, node) => {
-    if (err) {
-      return pull.error(err)
-    }
-    d.resolve(pull.values([node]))
-  })
-
   return pull(
-    d,
-    pull.map((result) => result.value),
-    pull.map((node) => resolve(node, path.base, path.rest, dag)),
-    pull.flatten()
+    pull.values([{
+      multihash: new CID(dPath.base),
+      name: dPath.base,
+      path: dPath.base,
+      pathRest: dPath.rest
+    }]),
+    createResolver(dag, options),
+    pull.map((node) => ({
+      path: finalPathFor(node),
+      size: node.size,
+      hash: node.hash,
+      content: node.content
+    }))
   )
+
+  function finalPathFor(node) {
+    if (!dPath.rest.length) {
+      return node.path
+    }
+
+    const cutElements = [dPath.base].concat(dPath.rest.slice(0, dPath.rest.length - 1))
+    const lengthToCut = join(cutElements).length
+    let retPath = node.path.substring(lengthToCut)
+    if (retPath.charAt(0) === '/') {
+      retPath = retPath.substring(1)
+    }
+    if (!retPath) {
+      retPath = dPath.rest[dPath.rest.length - 1] || dPath.base
+    }
+    return retPath
+  }
+}
+
+function join(paths) {
+  return paths.reduce((acc, path) => {
+    if (acc.length) {
+      acc += '/'
+    }
+    return acc + path
+  }, '')
 }

--- a/src/exporter/object.js
+++ b/src/exporter/object.js
@@ -2,29 +2,26 @@
 
 const CID = require('cids')
 const pull = require('pull-stream')
-const pullDefer = require('pull-defer')
 
-module.exports = (node, name, pathRest, ipldResolver, resolve) => {
+module.exports = (node, name, pathRest, resolve, dag, parent) => {
   let newNode
   if (pathRest.length) {
-    const pathElem = pathRest.shift()
+    const pathElem = pathRest[0]
     newNode = node[pathElem]
     const newName = name + '/' + pathElem
-    if (CID.isCID(newNode)) {
-      const d = pullDefer.source()
-      ipldResolver.get(sanitizeCID(newNode), (err, newNode) => {
-        if (err) {
-          d.resolve(pull.error(err))
-        } else {
-          d.resolve(resolve(newNode.value, newName, pathRest, ipldResolver, node))
-        }
-      })
-      return d
-    } else if (newNode !== undefined) {
-      return resolve(newNode, newName, pathRest, ipldResolver, node)
-    } else {
+    if (!newNode) {
       return pull.error('not found')
     }
+    const isCID = CID.isCID(newNode)
+    return pull(
+      pull.values([{
+        path: newName,
+        pathRest: pathRest.slice(1),
+        multihash: isCID && newNode,
+        object: !isCID && newNode,
+        parent: parent
+      }]),
+      resolve)
   } else {
     return pull.error(new Error('invalid node type'))
   }

--- a/src/exporter/object.js
+++ b/src/exporter/object.js
@@ -3,7 +3,7 @@
 const CID = require('cids')
 const pull = require('pull-stream')
 
-module.exports = (node, name, path, pathRest, resolve, dag, parent, depth) => {
+module.exports = (node, name, path, pathRest, resolve, size, dag, parent, depth) => {
   let newNode
   if (pathRest.length) {
     const pathElem = pathRest[0]

--- a/src/exporter/object.js
+++ b/src/exporter/object.js
@@ -26,7 +26,3 @@ module.exports = (node, name, pathRest, resolve, dag, parent) => {
     return pull.error(new Error('invalid node type'))
   }
 }
-
-function sanitizeCID (cid) {
-  return new CID(cid.version, cid.codec, cid.multihash)
-}

--- a/src/exporter/object.js
+++ b/src/exporter/object.js
@@ -3,18 +3,20 @@
 const CID = require('cids')
 const pull = require('pull-stream')
 
-module.exports = (node, name, pathRest, resolve, dag, parent) => {
+module.exports = (node, name, path, pathRest, resolve, dag, parent, depth) => {
   let newNode
   if (pathRest.length) {
     const pathElem = pathRest[0]
     newNode = node[pathElem]
-    const newName = name + '/' + pathElem
+    const newName = path + '/' + pathElem
     if (!newNode) {
       return pull.error('not found')
     }
     const isCID = CID.isCID(newNode)
     return pull(
       pull.values([{
+        depth: depth,
+        name: pathElem,
         path: newName,
         pathRest: pathRest.slice(1),
         multihash: isCID && newNode,

--- a/src/exporter/resolve.js
+++ b/src/exporter/resolve.js
@@ -18,11 +18,11 @@ module.exports = Object.assign({
 }, resolvers)
 
 function createResolver (dag, options, depth, parent) {
-  if (! depth) {
+  if (!depth) {
     depth = 0
   }
 
-  if (!options.recurse && depth > 0) {
+  if (depth > options.maxDepth) {
     return pull.map(identity)
   }
 
@@ -42,14 +42,14 @@ function createResolver (dag, options, depth, parent) {
     pull.flatten()
   )
 
-  function resolve (node, hash, pathRest, parentNode) {
+  function resolve (node, path, pathRest, parentNode) {
     const type = typeOf(node)
     const nodeResolver = resolvers[type]
     if (!nodeResolver) {
       return pull.error(new Error('Unkown node type ' + type))
     }
     const resolveDeep = createResolver(dag, options, depth + 1, node)
-    return nodeResolver(node, hash, pathRest, resolveDeep, dag, parentNode)
+    return nodeResolver(node, path, pathRest, resolveDeep, dag, parentNode)
   }
 }
 

--- a/src/exporter/resolve.js
+++ b/src/exporter/resolve.js
@@ -48,17 +48,17 @@ function createResolver (dag, options, depth, parent) {
   )
 
   function resolveItem (node, item) {
-    return resolve(node, item.name, item.path, item.pathRest, dag, item.parent || parent, item.depth)
+    return resolve(node, item.name, item.path, item.pathRest, item.size, dag, item.parent || parent, item.depth)
   }
 
-  function resolve (node, name, path, pathRest, dag, parentNode, depth) {
+  function resolve (node, name, path, pathRest, size, dag, parentNode, depth) {
     const type = typeOf(node)
     const nodeResolver = resolvers[type]
     if (!nodeResolver) {
       return pull.error(new Error('Unkown node type ' + type))
     }
     const resolveDeep = createResolver(dag, options, depth, node)
-    return nodeResolver(node, name, path, pathRest, resolveDeep, dag, parentNode, depth)
+    return nodeResolver(node, name, path, pathRest, resolveDeep, size, dag, parentNode, depth)
   }
 }
 

--- a/src/importer/tree-builder.js
+++ b/src/importer/tree-builder.js
@@ -91,7 +91,7 @@ function createTreeBuilder (ipldResolver, _options) {
   // ---- Add to tree
 
   function addToTree (elem, callback) {
-    const pathElems = elem.path.split('/').filter(notEmpty)
+    const pathElems = (elem.path || '').split('/').filter(notEmpty)
     let parent = tree
     const lastIndex = pathElems.length - 1
 

--- a/test/builder-dir-sharding.js
+++ b/test/builder-dir-sharding.js
@@ -91,7 +91,7 @@ module.exports = (repo) => {
             expect(nodes[0].path).to.be.eql(expectedHash)
             expect(mh.toB58String(nodes[0].hash)).to.be.eql(expectedHash)
             expect(nodes[1].path).to.be.eql(expectedHash + '/b')
-            expect(nodes[1].size).to.be.eql(21)
+            expect(nodes[1].size).to.be.eql(29)
             pull(
               nodes[1].content,
               pull.collect(collected)

--- a/test/exporter-subtree.js
+++ b/test/exporter-subtree.js
@@ -16,7 +16,7 @@ const exporter = unixFSEngine.exporter
 const smallFile = loadFixture(__dirname, 'fixtures/200Bytes.txt')
 
 module.exports = (repo) => {
-  describe('exporter', function () {
+  describe('exporter subtree', () => {
     this.timeout(10 * 1000)
 
     let ipldResolver

--- a/test/exporter-subtree.js
+++ b/test/exporter-subtree.js
@@ -17,7 +17,7 @@ const smallFile = loadFixture(__dirname, 'fixtures/200Bytes.txt')
 
 module.exports = (repo) => {
   describe('exporter subtree', () => {
-    this.timeout(10 * 1000)
+    // this.timeout(10 * 1000)
 
     let ipldResolver
 

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -74,6 +74,7 @@ module.exports = (repo) => {
     })
 
     it('export a small file with links', (done) => {
+      this.timeout(30 * 1000)
       const hash = 'QmW7BDxEbGqxxSYVtn3peNPQgdDXbWkoQ6J1EFYAEuQV3Q'
       pull(
         exporter(hash, ipldResolver),
@@ -83,9 +84,10 @@ module.exports = (repo) => {
           fileEql(files[0], bigFile, done)
         })
       )
-    }).timeout(30 * 1000)
+    })
 
     it('export a small file with links using CID instead of multihash', (done) => {
+      this.timeout(30 * 1000)
       const cid = new CID('QmW7BDxEbGqxxSYVtn3peNPQgdDXbWkoQ6J1EFYAEuQV3Q')
 
       pull(
@@ -96,9 +98,10 @@ module.exports = (repo) => {
           fileEql(files[0], bigFile, done)
         })
       )
-    }).timeout(30 * 1000)
+    })
 
     it('export a large file > 5mb', (done) => {
+      this.timeout(30 * 1000)
       const hash = 'QmRQgufjp9vLE8XK2LGKZSsPCFCF6e4iynCQtNB5X2HBKE'
       pull(
         exporter(hash, ipldResolver),
@@ -109,9 +112,10 @@ module.exports = (repo) => {
           fileEql(files[0], null, done)
         })
       )
-    }).timeout(30 * 1000)
+    })
 
     it('export a directory', (done) => {
+      this.timeout(30 * 1000)
       const hash = 'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN'
 
       pull(
@@ -149,9 +153,10 @@ module.exports = (repo) => {
           )
         })
       )
-    }).timeout(30 * 1000)
+    })
 
     it('export a directory one deep', (done) => {
+      this.timeout(30 * 1000)
       const hash = 'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN'
 
       pull(
@@ -185,7 +190,7 @@ module.exports = (repo) => {
           )
         })
       )
-    }).timeout(30 * 1000)
+    })
 
     it('returns an empty stream for dir', (done) => {
       const hash = 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -155,7 +155,7 @@ module.exports = (repo) => {
       const hash = 'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN'
 
       pull(
-        exporter(hash, ipldResolver, { maxDepth: 1}),
+        exporter(hash, ipldResolver, { maxDepth: 1 }),
         pull.collect((err, files) => {
           expect(err).to.not.exist()
           files.forEach(file => expect(file).to.have.property('hash'))

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -73,7 +73,7 @@ module.exports = (repo) => {
       )
     })
 
-    it('export a small file with links', (done) => {
+    it('export a small file with links', function (done) {
       this.timeout(30 * 1000)
       const hash = 'QmW7BDxEbGqxxSYVtn3peNPQgdDXbWkoQ6J1EFYAEuQV3Q'
       pull(
@@ -86,7 +86,7 @@ module.exports = (repo) => {
       )
     })
 
-    it('export a small file with links using CID instead of multihash', (done) => {
+    it('export a small file with links using CID instead of multihash', function (done) {
       this.timeout(30 * 1000)
       const cid = new CID('QmW7BDxEbGqxxSYVtn3peNPQgdDXbWkoQ6J1EFYAEuQV3Q')
 
@@ -100,7 +100,7 @@ module.exports = (repo) => {
       )
     })
 
-    it('export a large file > 5mb', (done) => {
+    it('export a large file > 5mb', function (done) {
       this.timeout(30 * 1000)
       const hash = 'QmRQgufjp9vLE8XK2LGKZSsPCFCF6e4iynCQtNB5X2HBKE'
       pull(
@@ -114,7 +114,7 @@ module.exports = (repo) => {
       )
     })
 
-    it('export a directory', (done) => {
+    it('export a directory', function (done) {
       this.timeout(30 * 1000)
       const hash = 'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN'
 
@@ -155,7 +155,7 @@ module.exports = (repo) => {
       )
     })
 
-    it('export a directory one deep', (done) => {
+    it('export a directory one deep', function (done) {
       this.timeout(30 * 1000)
       const hash = 'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN'
 

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -151,6 +151,42 @@ module.exports = (repo) => {
       )
     }).timeout(30 * 1000)
 
+    it('export a directory one deep', (done) => {
+      const hash = 'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN'
+
+      pull(
+        exporter(hash, ipldResolver, { maxDepth: 1}),
+        pull.collect((err, files) => {
+          expect(err).to.not.exist()
+          files.forEach(file => expect(file).to.have.property('hash'))
+
+          expect(
+            files.map((file) => file.path)
+          ).to.be.eql([
+            'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN',
+            'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/200Bytes.txt',
+            'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/dir-another',
+            'QmWChcSFMNcFkfeJtNd8Yru1rE6PhtCRfewi1tMwjkwKjN/level-1'
+          ])
+
+          pull(
+            pull.values(files),
+            pull.map((file) => Boolean(file.content)),
+            pull.collect((err, contents) => {
+              expect(err).to.not.exist()
+              expect(contents).to.be.eql([
+                false,
+                true,
+                false,
+                false
+              ])
+              done()
+            })
+          )
+        })
+      )
+    }).timeout(30 * 1000)
+
     it('returns an empty stream for dir', (done) => {
       const hash = 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'
 

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -117,8 +117,8 @@ module.exports = (repo) => {
       pull(
         exporter(hash, ipldResolver),
         pull.collect((err, files) => {
-          files.forEach(file => expect(file).to.have.property('hash'))
           expect(err).to.not.exist()
+          files.forEach(file => expect(file).to.have.property('hash'))
 
           expect(
             files.map((file) => file.path)

--- a/test/importer.js
+++ b/test/importer.js
@@ -311,7 +311,7 @@ module.exports = (repo) => {
             done()
           })
         )
-      })
+      }).timeout(60 * 1000)
 
       it('file bigger than a single chunk inside a dir', (done) => {
         pull(
@@ -331,7 +331,7 @@ module.exports = (repo) => {
             done()
           })
         )
-      })
+      }).timeout(60 * 1000)
 
       it('empty directory', (done) => {
         pull(

--- a/test/importer.js
+++ b/test/importer.js
@@ -299,6 +299,7 @@ module.exports = (repo) => {
       })
 
       it('file bigger than a single chunk', (done) => {
+        this.timeout(60 * 1000)
         pull(
           pull.values([{
             path: '1.2MiB.txt',
@@ -311,9 +312,10 @@ module.exports = (repo) => {
             done()
           })
         )
-      }).timeout(60 * 1000)
+      })
 
       it('file bigger than a single chunk inside a dir', (done) => {
+        this.timeout(60 * 1000)
         pull(
           pull.values([{
             path: 'foo-big/1.2MiB.txt',
@@ -331,7 +333,7 @@ module.exports = (repo) => {
             done()
           })
         )
-      }).timeout(60 * 1000)
+      })
 
       it('empty directory', (done) => {
         pull(

--- a/test/importer.js
+++ b/test/importer.js
@@ -298,7 +298,7 @@ module.exports = (repo) => {
         }
       })
 
-      it('file bigger than a single chunk', (done) => {
+      it('file bigger than a single chunk', function (done) {
         this.timeout(60 * 1000)
         pull(
           pull.values([{
@@ -314,7 +314,7 @@ module.exports = (repo) => {
         )
       })
 
-      it('file bigger than a single chunk inside a dir', (done) => {
+      it('file bigger than a single chunk inside a dir', function (done) {
         this.timeout(60 * 1000)
         pull(
           pull.values([{


### PR DESCRIPTION
In order to be able to efficiently do an `ipfs.files.ls`, and for it to be correct, supporting not only dirs but also shardeddirs, the best way IMO is to integrate this into the exporter, introducing an optional `maxDepth` option.

To fully make this happen:

- [x] - major exporter overhaul, concentrating dag resolving (to be able to control recursion)
- [x] - code to support maxDepth
- [x] - test maxDepth