### PR TITLE
chore: update multihashing-async

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "left-pad": "^1.2.0",
     "lodash": "^4.17.4",
     "multihashes": "~0.4.12",
-    "multihashing-async": "~0.4.7",
+    "multihashing-async": "~0.4.8",
     "pull-batch": "^1.0.0",
     "pull-block": "^1.4.0",
     "pull-cat": "^1.1.11",


### PR DESCRIPTION
This new version of multishashing-async supports the double SHA2-256
hashing, which is use by e.g. Bitcoin/Zcash. It is needed in order
to pass the test suite.

Fixes #203.