### PR TITLE
test: Increase timeout of a test

### DIFF
--- a/test/hash-parity-with-go-ipfs.js
+++ b/test/hash-parity-with-go-ipfs.js
@@ -38,7 +38,8 @@ module.exports = (repo) => {
         ipldResolver = new IPLDResolver(bs)
       })
 
-      it('yields the same tree as go-ipfs', (done) => {
+      it('yields the same tree as go-ipfs', function (done) {
+        this.timeout(10 * 1000)
         pull(
           pull.values([
             {


### PR DESCRIPTION
The test in `hash-parity-with-go-ipfs.js` timed out even locally,
hence increasing the timeout to 10 seconds.