### PR TITLE
chore: Conform to spec for stream slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,9 @@ Creates a new readable stream in object mode that outputs objects of the form
 }
 ```
 
-#### `begin` and `end`
+#### `offset` and `length`
 
-`begin` and `end` arguments can optionally be passed to the reader function.  These follow the same semantics as the JavaScript [`Array.slice(begin, end)`][] method.
-
-That is: `begin` is the index in the stream to start sending data, `end` is the index *before* which to stop sending data.
-
-A negative `begin` starts the slice from the end of the stream and a negative `end` ends the slice by subtracting `end` from the total stream length.
+`offset` and `length` arguments can optionally be passed to the reader function.  These will cause the returned stream to only emit bytes starting at `offset` and with length of `length`.
 
 See [the tests](test/reader.js) for examples of using these arguments.
 
@@ -195,8 +191,8 @@ const drain = require('pull-stream/sinks/drain')
 
 pull(
   exporter(cid, ipldResolver, {
-    begin: 0,
-    end: 10
+    offset: 0,
+    length: 10
   })
   drain((file) => {
     // file.content() is a pull stream containing only the first 10 bytes of the file
@@ -225,7 +221,6 @@ pull(
 [ipld-resolver instance]: https://github.com/ipld/js-ipld-resolver
 [UnixFS]: https://github.com/ipfs/specs/tree/master/unixfs
 [pull-stream]: https://www.npmjs.com/package/pull-stream
-[`Array.slice(begin, end)`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
 
 ## Contribute
 

--- a/src/exporter/index.js
+++ b/src/exporter/index.js
@@ -37,8 +37,8 @@ function pathBaseAndRest (path) {
 
 const defaultOptions = {
   maxDepth: Infinity,
-  begin: undefined,
-  end: undefined
+  offset: undefined,
+  length: undefined
 }
 
 module.exports = (path, dag, options) => {

--- a/src/exporter/resolve.js
+++ b/src/exporter/resolve.js
@@ -32,14 +32,14 @@ function createResolver (dag, options, depth, parent) {
         return pull.error(new Error('no depth'))
       }
       if (item.object) {
-        return cb(null, resolveItem(item.object, item, options.begin, options.end))
+        return cb(null, resolveItem(item.object, item, options.offset, options.length))
       }
       dag.get(new CID(item.multihash), (err, node) => {
         if (err) {
           return cb(err)
         }
         // const name = item.fromPathRest ? item.name : item.path
-        cb(null, resolveItem(node.value, item, options.begin, options.end))
+        cb(null, resolveItem(node.value, item, options.offset, options.length))
       })
     }),
     pull.flatten(),
@@ -47,18 +47,18 @@ function createResolver (dag, options, depth, parent) {
     pull.filter((node) => node.depth <= options.maxDepth)
   )
 
-  function resolveItem (node, item, begin, end) {
-    return resolve(node, item.name, item.path, item.pathRest, item.size, dag, item.parent || parent, item.depth, begin, end)
+  function resolveItem (node, item, offset, length) {
+    return resolve(node, item.name, item.path, item.pathRest, item.size, dag, item.parent || parent, item.depth, offset, length)
   }
 
-  function resolve (node, name, path, pathRest, size, dag, parentNode, depth, begin, end) {
+  function resolve (node, name, path, pathRest, size, dag, parentNode, depth, offset, length) {
     const type = typeOf(node)
     const nodeResolver = resolvers[type]
     if (!nodeResolver) {
       return pull.error(new Error('Unkown node type ' + type))
     }
     const resolveDeep = createResolver(dag, options, depth, node)
-    return nodeResolver(node, name, path, pathRest, resolveDeep, size, dag, parentNode, depth, begin, end)
+    return nodeResolver(node, name, path, pathRest, resolveDeep, size, dag, parentNode, depth, offset, length)
   }
 }
 


### PR DESCRIPTION
See ipfs/interface-ipfs-core#242 for discussion.

Removes the JavaScript-like `stream.slice(begin, end)` semantics in favour of `stream.slice(offset, length)`.