### PR TITLE
chore: use same hash for empty node as go

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cids": "~0.5.3",
     "deep-extend": "~0.6.0",
     "ipfs-unixfs": "~0.1.14",
-    "ipld": "^0.17.2",
+    "ipld": "~0.17.2",
     "ipld-dag-pb": "~0.14.4",
     "left-pad": "^1.3.0",
     "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "bs58": "^4.0.1",
     "cids": "~0.5.3",
     "deep-extend": "~0.6.0",
-    "ipfs-unixfs": "~0.1.14",
+    "ipfs-unixfs": "~0.1.15",
     "ipld": "~0.17.2",
     "ipld-dag-pb": "~0.14.4",
     "left-pad": "^1.3.0",

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -63,15 +63,11 @@ function streamBytes (dag, node, fileSize, offset, length) {
   let streamPosition = 0
 
   function getData ({ node, start }) {
-    if (!node || !node.data) {
-      return
-    }
-
     try {
       const file = UnixFS.unmarshal(node.data)
 
       if (!file.data) {
-        return
+        return Buffer.alloc(0)
       }
 
       const block = extractDataFromBlock(file.data, start, offset, end)

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -30,7 +30,7 @@ module.exports = (node, name, path, pathRest, resolve, size, dag, parent, depth,
   }
 
   if (length === 0) {
-    return pull.empty()
+    return pull.once(Buffer.alloc(0))
   }
 
   if (!offset) {
@@ -56,7 +56,7 @@ module.exports = (node, name, path, pathRest, resolve, size, dag, parent, depth,
 
 function streamBytes (dag, node, fileSize, offset, length) {
   if (offset === fileSize || length === 0) {
-    return pull.empty()
+    return pull.once(Buffer.alloc(0))
   }
 
   const end = offset + length

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -139,6 +139,12 @@ function streamBytes (dag, node, fileSize, offset, length) {
 function extractDataFromBlock (block, streamPosition, begin, end) {
   const blockLength = block.length
 
+  if (begin >= streamPosition + blockLength) {
+    // If begin is after the start of the block, return an empty block
+    // This can happen when internal nodes contain data
+    return Buffer.alloc(0)
+  }
+
   if (end - streamPosition < blockLength) {
     // If the end byte is in the current block, truncate the block to the end byte
     block = block.slice(0, end - streamPosition)

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -713,6 +713,27 @@ module.exports = (repo) => {
         }
       ], done)
     })
+
+    it('exports file with data on internal and leaf nodes with an offset that only fetches data from leaf nodes', function (done) {
+      waterfall([
+        (cb) => createAndPersistNode(ipld, 'raw', [0x04, 0x05, 0x06, 0x07], [], cb),
+        (leaf, cb) => createAndPersistNode(ipld, 'file', [0x00, 0x01, 0x02, 0x03], [
+          leaf
+        ], cb),
+        (file, cb) => {
+          pull(
+            exporter(file.multihash, ipld, {
+              offset: 4
+            }),
+            pull.asyncMap((file, cb) => readFile(file, cb)),
+            pull.through(buffer => {
+              expect(buffer).to.deep.equal(Buffer.from([0x04, 0x05, 0x06, 0x07]))
+            }),
+            pull.collect(cb)
+          )
+        }
+      ], done)
+    })
   })
 }
 

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -82,10 +82,8 @@ module.exports = (repo) => {
       pull(
         input,
         pull.map((file) => {
-          const ipfsPath = `${path.join(dirName, file.substring(directory.length))}`
-
           return {
-            path: ipfsPath,
+            path: path.join(dirName, path.basename(file)),
             content: toPull.source(fs.createReadStream(file))
           }
         }),

--- a/test/importer.js
+++ b/test/importer.js
@@ -214,7 +214,7 @@ module.exports = (repo) => {
             expect(err).to.not.exist()
             expect(nodes.length).to.be.eql(1)
             // always yield empty node
-            expect(mh.toB58String(nodes[0].multihash)).to.be.eql('QmfJMCvenrj4SKKRc48DYPxwVdS44qCUCqqtbqhJuSTWXP')
+            expect(mh.toB58String(nodes[0].multihash)).to.be.eql('QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')
             done()
           }))
       })

--- a/test/importer.js
+++ b/test/importer.js
@@ -7,7 +7,7 @@ const extend = require('deep-extend')
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const sinon = require('sinon')
+const spy = require('sinon/lib/sinon/spy')
 const BlockService = require('ipfs-block-service')
 const pull = require('pull-stream')
 const mh = require('multihashes')
@@ -456,7 +456,7 @@ module.exports = (repo) => {
       })
 
       it('will call an optional progress function', (done) => {
-        options.progress = sinon.spy()
+        options.progress = spy()
 
         pull(
           pull.values([{

--- a/test/node.js
+++ b/test/node.js
@@ -10,8 +10,8 @@ const mkdirp = require('mkdirp')
 const series = require('async/series')
 
 describe('IPFS UnixFS Engine', () => {
-  const repoExample = path.join(process.cwd(), '/test/test-repo')
-  const repoTests = path.join(os.tmpdir(), '/unixfs-tests-' + Date.now())
+  const repoExample = path.join(process.cwd(), 'test', 'test-repo')
+  const repoTests = path.join(os.tmpdir(), 'unixfs-tests-' + Date.now())
 
   const repo = new IPFSRepo(repoTests)
 

--- a/test/with-dag-api.js
+++ b/test/with-dag-api.js
@@ -225,7 +225,7 @@ describe('with dag-api', function () {
             expect(err).to.not.exist()
             expect(nodes.length).to.be.eql(1)
             // always yield empty node
-            expect(mh.toB58String(nodes[0].multihash)).to.be.eql('QmfJMCvenrj4SKKRc48DYPxwVdS44qCUCqqtbqhJuSTWXP')
+            expect(mh.toB58String(nodes[0].multihash)).to.be.eql('QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')
             done()
           }))
       })


### PR DESCRIPTION
Fixes the breakage that ipfs/js-ipfs-unixfs#25 causes.