### PR TITLE
feat: support --raw-leaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ The input's file paths and directory structure will be preserved in the [`dag-pb
 - `onlyHash` (boolean, defaults to false): Only chunk and hash - do not write to disk
 - `hashAlg` (string): multihash hashing algorithm to use
 - `cidVersion` (integer, default 0): the CID version to use when storing the data (storage keys are based on the CID, _including_ it's version)
-- `rawLeafNodes` (boolean, defaults to false): When a file would span multiple DAGNodes, if this is true the leaf nodes will be marked as `raw` `unixfs` nodes
+- `rawLeaves` (boolean, defaults to false): When a file would span multiple DAGNodes, if this is true the leaf nodes will not be wrapped in `UnixFS` protobufs and will instead contain the raw file bytes
+- `leafType` (string, defaults to `'file'`) what type of UnixFS node leaves should be - can be `'file'` or `'raw'` (ignored when `rawLeaves` is `true`)
 
 ### Exporter
 

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -63,6 +63,11 @@ function streamBytes (dag, node, fileSize, offset, length) {
 
   function getData ({ node, start }) {
     try {
+      if (Buffer.isBuffer(node)) {
+        // this is a raw node
+        return extractDataFromBlock(node, start, offset, end)
+      }
+
       const file = UnixFS.unmarshal(node.data)
 
       if (!file.data) {
@@ -80,6 +85,11 @@ function streamBytes (dag, node, fileSize, offset, length) {
   let streamPosition = 0
 
   function visitor ({ node }) {
+    if (Buffer.isBuffer(node)) {
+      // this is a raw node
+      return pull.empty()
+    }
+
     const file = UnixFS.unmarshal(node.data)
     const nodeHasData = Boolean(file.data && file.data.length)
 

--- a/src/importer/index.js
+++ b/src/importer/index.js
@@ -15,11 +15,29 @@ const chunkers = {
 
 const defaultOptions = {
   chunker: 'fixed',
-  rawLeafNodes: false
+  rawLeaves: false,
+  hashOnly: false,
+  cidVersion: 0,
+  hash: null,
+  leafType: 'file',
+  hashAlg: 'sha2-256'
 }
 
 module.exports = function (ipld, _options) {
   const options = Object.assign({}, defaultOptions, _options)
+
+  if (options.cidVersion > 0 && _options.rawLeaves === undefined) {
+    // if the cid version is 1 or above, use raw leaves as this is
+    // what go does.
+    options.rawLeaves = true
+  }
+
+  if (_options && _options.hash !== undefined && _options.rawLeaves === undefined) {
+    // if a non-default hash alg has been specified, use raw leaves as this is
+    // what go does.
+    options.rawLeaves = true
+  }
+
   const Chunker = chunkers[options.chunker]
   assert(Chunker, 'Unknkown chunker named ' + options.chunker)
 

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -422,6 +422,37 @@ module.exports = (repo) => {
       )
     })
 
+    it('exports a large file > 5mb imported with raw leaves', function (done) {
+      this.timeout(30 * 1000)
+
+      pull(
+        pull.values([{
+          path: '200Bytes.txt',
+          content: pull.values([bigFile])
+        }]),
+        importer(ipld, {
+          rawLeaves: true
+        }),
+        pull.collect(collected)
+      )
+
+      function collected (err, files) {
+        expect(err).to.not.exist()
+        expect(files.length).to.equal(1)
+
+        pull(
+          exporter(files[0].multihash, ipld),
+          pull.collect((err, files) => {
+            expect(err).to.not.exist()
+
+            expect(bs58.encode(files[0].hash)).to.equal('QmQLTvhjmSa7657mKdSfTjxFBdwxmK8n9tZC9Xdp9DtxWY')
+
+            fileEql(files[0], bigFile, done)
+          })
+        )
+      }
+    })
+
     it('returns an empty stream for dir', (done) => {
       const hash = 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn'
 

--- a/test/helpers/collect-leaf-cids.js
+++ b/test/helpers/collect-leaf-cids.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const pull = require('pull-stream')
+const traverse = require('pull-traverse')
+const CID = require('cids')
+
+module.exports = (ipld, multihash, callback) => {
+  pull(
+    traverse.depthFirst(new CID(multihash), (cid) => {
+      return pull(
+        pull.values([cid]),
+        pull.asyncMap((cid, callback) => {
+          ipld.get(cid, (error, result) => {
+            callback(error, !error && result.value)
+          })
+        }),
+        pull.asyncMap((node, callback) => {
+          if (!node.links) {
+            return callback()
+          }
+
+          return callback(
+            null, node.links.map(link => new CID(link.multihash))
+          )
+        }),
+        pull.filter(Boolean),
+        pull.flatten()
+      )
+    }),
+    pull.collect(callback)
+  )
+}


### PR DESCRIPTION
Goes some way towards fixing ipfs/js-ipfs#1432 - will need follow up PRs for `js-ipfs-mfs` and `js-ipfs` itself (🔜).

There are three ways of importing a file we need to support and each will end up with slightly different DAG structure.

1. `ipfs add` will result in a balanced DAG with leaf nodes that are `unixfs` nodes of type `file`
1. `ipfs files write` results in a trickle DAG with leaf nodes that are `unixfs` nodes of type `raw`
1. `ipfs add --raw-leaves` and `ipfs files write --raw-leaves` have the balanced/trickle DAG of above, but the leaf nodes are chunks of file data not wrapped in protobufs.

In all cases above the root node is a `unixfs` `file` node with a v0 CID, unless you specify `--cid-version=1`.

This PR:

* Changes the meaning of existing `rawLeaves` argument. It now means the leaf node is just data - a chunk of the file - this is consistent with go.  Previously it was meant a `unixfs` node with type `raw`.  So far the only code using this is `js-ipfs-mfs` so changing it shouldn't be too disruptive.
* Adds a `leafType` option which can be `file` or `raw` - when `--raw-leaves` is false, this is what the `unixfs` leaf type will be.
* Uses CIDv1 for raw leaves with the codec `raw`