### PR TITLE
Add support for rabin fingerprinting chunk algorithm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "leadMaintainer": "Alex Potsides <alex.potsides@protocol.ai>",
   "main": "src/index.js",
   "browser": {
-    "fs": false
+    "fs": false,
+    "rabin": false
   },
   "scripts": {
     "test": "aegir test",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
     "pull-through": "^1.0.18",
     "pull-traverse": "^1.0.3",
     "pull-write": "^1.1.4",
-    "sparse-array": "^1.3.1"
+    "rabin": "^1.6.0",
+    "sparse-array": "^1.3.1",
+    "stream-to-pull-stream": "^1.7.2"
   },
   "contributors": [
     "Alan Shaw <alan@tableflip.io>",

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -16,7 +16,8 @@ const DAGNode = dagPB.DAGNode
 
 const defaultOptions = {
   chunkerOptions: {
-    maxChunkSize: 262144
+    maxChunkSize: 262144,
+    avgChunkSize: 262144
   },
   rawLeaves: false,
   hashAlg: 'sha2-256',

--- a/src/chunker/index.js
+++ b/src/chunker/index.js
@@ -3,12 +3,8 @@
 const rabin = require('rabin')
 
 const chunkers = {
-  fixed: require('../chunker/fixed-size')
-}
-
-// Don't include the rabin chunker when rabin require is null for browser
-if (rabin) {
-  chunkers.rabin = require('../chunker/rabin')
+  fixed: require('../chunker/fixed-size'),
+  rabin: require('../chunker/rabin')
 }
 
 module.exports = chunkers

--- a/src/chunker/index.js
+++ b/src/chunker/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const rabin = require('rabin')
 
 const chunkers = {

--- a/src/chunker/index.js
+++ b/src/chunker/index.js
@@ -1,0 +1,12 @@
+const rabin = require('rabin')
+
+const chunkers = {
+  fixed: require('../chunker/fixed-size')
+}
+
+// Don't include the rabin chunker when rabin require is null for browser
+if (rabin) {
+  chunkers.rabin = require('../chunker/rabin')
+}
+
+module.exports = chunkers

--- a/src/chunker/rabin.js
+++ b/src/chunker/rabin.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const createRabin = require('rabin')
+const toPull = require('stream-to-pull-stream')
+
+module.exports = (options) => {
+  let min, max, avg;
+  if (options.minChunkSize && options.maxChunkSize && options.avgChunkSize) {
+    avg = options.avgChunkSize
+    min = options.minChunkSize
+    max = options.maxChunkSize
+  } else {
+    avg = options.avgChunkSize
+    min = avg / 3
+    max = avg + (avg / 2)
+  }
+
+  const sizepow = Math.floor(Math.log2(avg))
+  const rabin = createRabin({
+    min: min,
+    max: max,
+    bits: sizepow,
+    window: options.window || 16,
+    polynomial: options.polynomial || "0x3DF305DFB2A805"
+  })
+
+  return toPull.duplex(rabin)
+}

--- a/src/chunker/rabin.js
+++ b/src/chunker/rabin.js
@@ -4,7 +4,7 @@ const createRabin = require('rabin')
 const toPull = require('stream-to-pull-stream')
 
 module.exports = (options) => {
-  let min, max, avg;
+  let min, max, avg
   if (options.minChunkSize && options.maxChunkSize && options.avgChunkSize) {
     avg = options.avgChunkSize
     min = options.minChunkSize
@@ -21,7 +21,7 @@ module.exports = (options) => {
     max: max,
     bits: sizepow,
     window: options.window || 16,
-    polynomial: options.polynomial || "0x3DF305DFB2A805"
+    polynomial: options.polynomial || '0x3DF305DFB2A805'
   })
 
   return toPull.duplex(rabin)

--- a/src/importer/index.js
+++ b/src/importer/index.js
@@ -8,10 +8,7 @@ const assert = require('assert')
 const setImmediate = require('async/setImmediate')
 const DAGBuilder = require('../builder')
 const createTreeBuilder = require('./tree-builder')
-
-const chunkers = {
-  fixed: require('../chunker/fixed-size')
-}
+const chunkers = require('../chunker')
 
 const defaultOptions = {
   chunker: 'fixed',

--- a/test/chunker-rabin.js
+++ b/test/chunker-rabin.js
@@ -27,9 +27,7 @@ describe('chunker: rabin', function () {
       chunker({minChunkSize: 48, avgChunkSize: 96, maxChunkSize: 192}),
       pull.collect((err, chunks) => {
         expect(err).to.not.exist()
-        let totalSize = 0
         chunks.forEach((chunk) => {
-          totalSize += chunk.length
           expect(chunk).to.have.length.gte(48)
           expect(chunk).to.have.length.lte(192)
         })
@@ -42,7 +40,7 @@ describe('chunker: rabin', function () {
     const KiB256 = 262144
     let file = Buffer.concat([rawFile, Buffer.from('hello')])
     const opts = {
-      minChunkSize: KiB256/3, 
+      minChunkSize: KiB256 / 3,
       avgChunkSize: KiB256,
       maxChunkSize: KiB256 + (KiB256 / 2)
     }
@@ -61,5 +59,4 @@ describe('chunker: rabin', function () {
       })
     )
   })
-
 })

--- a/test/chunker-rabin.js
+++ b/test/chunker-rabin.js
@@ -1,0 +1,65 @@
+/* eslint-env mocha */
+'use strict'
+
+const chunker = require('./../src/chunker/rabin')
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+const expect = chai.expect
+const pull = require('pull-stream')
+const loadFixture = require('aegir/fixtures')
+
+const rawFile = loadFixture('test/fixtures/1MiB.txt')
+
+describe('chunker: rabin', function () {
+  this.timeout(30000)
+
+  it('chunks non flat buffers', (done) => {
+    const b1 = Buffer.alloc(2 * 256)
+    const b2 = Buffer.alloc(1 * 256)
+    const b3 = Buffer.alloc(5 * 256)
+
+    b1.fill('a')
+    b2.fill('b')
+    b3.fill('c')
+
+    pull(
+      pull.values([b1, b2, b3]),
+      chunker({minChunkSize: 48, avgChunkSize: 96, maxChunkSize: 192}),
+      pull.collect((err, chunks) => {
+        expect(err).to.not.exist()
+        let totalSize = 0
+        chunks.forEach((chunk) => {
+          totalSize += chunk.length
+          expect(chunk).to.have.length.gte(48)
+          expect(chunk).to.have.length.lte(192)
+        })
+        done()
+      })
+    )
+  })
+
+  it('256 KiB avg chunks of non scalar filesize', (done) => {
+    const KiB256 = 262144
+    let file = Buffer.concat([rawFile, Buffer.from('hello')])
+    const opts = {
+      minChunkSize: KiB256/3, 
+      avgChunkSize: KiB256,
+      maxChunkSize: KiB256 + (KiB256 / 2)
+    }
+    pull(
+      pull.values([file]),
+      chunker(opts),
+      pull.collect((err, chunks) => {
+        expect(err).to.not.exist()
+
+        chunks.forEach((chunk) => {
+          expect(chunk).to.have.length.gte(opts.minChunkSize)
+          expect(chunk).to.have.length.lte(opts.maxChunkSize)
+        })
+
+        done()
+      })
+    )
+  })
+
+})


### PR DESCRIPTION
This currently works as is, however the parameters `polynomial` and `windowsize` are not configurable by the rabin library used. This makes it difficult to compare the output the go-ipfs implementation, since both these parameters are set to different values there.

I have opened a PR against the rabin library to allow for these parameters to be modified from javascript, datproject/rabin/pull/24.

Could use some advice on testing, the nature of the rabin chunking makes it difficult to test things like expected block sizes.

These changes are required for ipfs/js-ipfs/issues/1283