### PR TITLE
fix: do not emit empty buffers for non-empty files

### DIFF
--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -71,6 +71,10 @@ function streamBytes (dag, node, fileSize, offset, length) {
       const file = UnixFS.unmarshal(node.data)
 
       if (!file.data) {
+        if (file.blockSizes.length) {
+          return
+        }
+
         return Buffer.alloc(0)
       }
 

--- a/test/builder.js
+++ b/test/builder.js
@@ -62,7 +62,9 @@ module.exports = (repo) => {
       }, done)
     })
 
-    it('allows multihash hash algorithm to be specified for big file', (done) => {
+    it('allows multihash hash algorithm to be specified for big file', function (done) {
+      this.timeout(30000)
+
       eachSeries(testMultihashes, (hashAlg, cb) => {
         const options = { hashAlg, strategy: 'flat' }
         const content = String(Math.random() + Date.now())

--- a/test/exporter.js
+++ b/test/exporter.js
@@ -763,6 +763,47 @@ module.exports = (repo) => {
         }
       ], done)
     })
+
+    it('exports file with data on leaf nodes without emitting empty buffers', function (done) {
+      this.timeout(30 * 1000)
+
+      pull(
+        pull.values([{
+          path: '200Bytes.txt',
+          content: pull.values([bigFile])
+        }]),
+        importer(ipld, {
+          rawLeaves: true
+        }),
+        pull.collect(collected)
+      )
+
+      function collected (err, files) {
+        expect(err).to.not.exist()
+        expect(files.length).to.equal(1)
+
+        pull(
+          exporter(files[0].multihash, ipld),
+          pull.collect((err, files) => {
+            expect(err).to.not.exist()
+            expect(files.length).to.equal(1)
+
+            pull(
+              files[0].content,
+              pull.collect((error, buffers) => {
+                expect(error).to.not.exist()
+
+                buffers.forEach(buffer => {
+                  expect(buffer.length).to.not.equal(0)
+                })
+
+                done()
+              })
+            )
+          })
+        )
+      }
+    })
   })
 }
 


### PR DESCRIPTION
If a UnixFS file node has no data but does have blockSizes (e.g. data is stored in child nodes) do not emit an empty buffer for the containing node.