### PR TITLE
fix: import with CID version 1

### DIFF
--- a/src/builder/reduce.js
+++ b/src/builder/reduce.js
@@ -27,7 +27,8 @@ module.exports = function reduce (file, ipld, options) {
       return waterfall([
         (cb) => ipld.get(leaf.cid, cb),
         (result, cb) => {
-          const data = result.value.data
+          // If result.value is a buffer, this is a raw leaf otherwise it's a dag-pb node
+          const data = Buffer.isBuffer(result.value) ? result.value : result.value.data
           const fileNode = new UnixFS('file', data)
 
           DAGNode.create(fileNode.marshal(), [], options.hashAlg, (error, node) => {


### PR DESCRIPTION
Using CID version 1 causes the raw leaves option to become `true` unless specified. The builder reducer was not expecting a raw leaf to be returned by `ipld.get` so was creating file nodes with empty data.

Improves the test to fetch the data for the CIDs created by the importer and assert the imported data is the same as the input data.

fixes https://github.com/ipfs/js-ipfs/issues/1518