### PR TITLE
fix: build & export interop with go-ipfs for small file raw leaves

### DIFF
--- a/src/builder/reduce.js
+++ b/src/builder/reduce.js
@@ -13,51 +13,13 @@ module.exports = function reduce (file, ipld, options) {
     if (leaves.length === 1 && leaves[0].single && options.reduceSingleLeafToSelf) {
       const leaf = leaves[0]
 
-      if (options.leafType === 'file' && !options.rawLeaves) {
-        return callback(null, {
-          path: file.path,
-          multihash: leaf.multihash,
-          size: leaf.size,
-          leafSize: leaf.leafSize,
-          name: leaf.name
-        })
-      }
-
-      // we're using raw leaf nodes so we convert the node into a UnixFS `file` node.
-      return waterfall([
-        (cb) => ipld.get(leaf.cid, cb),
-        (result, cb) => {
-          // If result.value is a buffer, this is a raw leaf otherwise it's a dag-pb node
-          const data = Buffer.isBuffer(result.value) ? result.value : result.value.data
-          const fileNode = new UnixFS('file', data)
-
-          DAGNode.create(fileNode.marshal(), [], options.hashAlg, (error, node) => {
-            cb(error, { DAGNode: node, fileNode: fileNode })
-          })
-        },
-        (result, cb) => {
-          if (options.onlyHash) {
-            return cb(null, result)
-          }
-
-          let cid = new CID(result.DAGNode.multihash)
-
-          if (options.cidVersion === 1) {
-            cid = cid.toV1()
-          }
-
-          ipld.put(result.DAGNode, { cid }, (error) => cb(error, result))
-        },
-        (result, cb) => {
-          cb(null, {
-            path: file.path,
-            multihash: result.DAGNode.multihash,
-            size: result.DAGNode.size,
-            leafSize: result.fileNode.fileSize(),
-            name: leaf.name
-          })
-        }
-      ], callback)
+      return callback(null, {
+        path: file.path,
+        multihash: leaf.multihash,
+        size: leaf.size,
+        leafSize: leaf.leafSize,
+        name: leaf.name
+      })
     }
 
     // create a parent node and add all the leaves

--- a/src/exporter/clean-multihash.js
+++ b/src/exporter/clean-multihash.js
@@ -1,7 +1,0 @@
-'use strict'
-
-const CID = require('cids')
-
-module.exports = (multihash) => {
-  return new CID(multihash).toBaseEncodedString()
-}

--- a/src/exporter/dir-flat.js
+++ b/src/exporter/dir-flat.js
@@ -6,14 +6,14 @@ const cat = require('pull-cat')
 // Logic to export a unixfs directory.
 module.exports = dirExporter
 
-function dirExporter (node, name, path, pathRest, resolve, size, dag, parent, depth) {
+function dirExporter (cid, node, name, path, pathRest, resolve, size, dag, parent, depth) {
   const accepts = pathRest[0]
 
   const dir = {
     name: name,
     depth: depth,
     path: path,
-    hash: node.multihash,
+    hash: cid,
     size: node.size,
     type: 'dir'
   }

--- a/src/exporter/dir-hamt-sharded.js
+++ b/src/exporter/dir-hamt-sharded.js
@@ -2,19 +2,18 @@
 
 const pull = require('pull-stream')
 const cat = require('pull-cat')
-const cleanHash = require('./clean-multihash')
 
 // Logic to export a unixfs directory.
 module.exports = shardedDirExporter
 
-function shardedDirExporter (node, name, path, pathRest, resolve, size, dag, parent, depth) {
+function shardedDirExporter (cid, node, name, path, pathRest, resolve, size, dag, parent, depth) {
   let dir
   if (!parent || (parent.path !== path)) {
     dir = {
       name: name,
       depth: depth,
       path: path,
-      hash: cleanHash(node.multihash),
+      hash: cid,
       size: node.size,
       type: 'dir'
     }

--- a/src/exporter/extract-data-from-block.js
+++ b/src/exporter/extract-data-from-block.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports = function extractDataFromBlock (block, streamPosition, begin, end) {
+  const blockLength = block.length
+
+  if (begin >= streamPosition + blockLength) {
+    // If begin is after the start of the block, return an empty block
+    // This can happen when internal nodes contain data
+    return Buffer.alloc(0)
+  }
+
+  if (end - streamPosition < blockLength) {
+    // If the end byte is in the current block, truncate the block to the end byte
+    block = block.slice(0, end - streamPosition)
+  }
+
+  if (begin > streamPosition && begin < (streamPosition + blockLength)) {
+    // If the start byte is in the current block, skip to the start byte
+    block = block.slice(begin - streamPosition)
+  }
+
+  return block
+}

--- a/src/exporter/file.js
+++ b/src/exporter/file.js
@@ -5,9 +5,10 @@ const UnixFS = require('ipfs-unixfs')
 const CID = require('cids')
 const pull = require('pull-stream')
 const paramap = require('pull-paramap')
+const extractDataFromBlock = require('./extract-data-from-block')
 
 // Logic to export a single (possibly chunked) unixfs file.
-module.exports = (node, name, path, pathRest, resolve, size, dag, parent, depth, offset, length) => {
+module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, depth, offset, length) => {
   const accepts = pathRest[0]
 
   if (accepts !== undefined && accepts !== path) {
@@ -48,7 +49,7 @@ module.exports = (node, name, path, pathRest, resolve, size, dag, parent, depth,
     content: content,
     name: name,
     path: path,
-    hash: node.multihash,
+    hash: cid,
     size: fileSize,
     type: 'file'
   }])
@@ -148,26 +149,4 @@ function streamBytes (dag, node, fileSize, offset, length) {
     pull.map(getData),
     pull.filter(Boolean)
   )
-}
-
-function extractDataFromBlock (block, streamPosition, begin, end) {
-  const blockLength = block.length
-
-  if (begin >= streamPosition + blockLength) {
-    // If begin is after the start of the block, return an empty block
-    // This can happen when internal nodes contain data
-    return Buffer.alloc(0)
-  }
-
-  if (end - streamPosition < blockLength) {
-    // If the end byte is in the current block, truncate the block to the end byte
-    block = block.slice(0, end - streamPosition)
-  }
-
-  if (begin > streamPosition && begin < (streamPosition + blockLength)) {
-    // If the start byte is in the current block, skip to the start byte
-    block = block.slice(begin - streamPosition)
-  }
-
-  return block
 }

--- a/src/exporter/object.js
+++ b/src/exporter/object.js
@@ -3,7 +3,7 @@
 const CID = require('cids')
 const pull = require('pull-stream')
 
-module.exports = (node, name, path, pathRest, resolve, size, dag, parent, depth) => {
+module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, depth) => {
   let newNode
   if (pathRest.length) {
     const pathElem = pathRest[0]

--- a/src/exporter/raw.js
+++ b/src/exporter/raw.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const pull = require('pull-stream')
+const extractDataFromBlock = require('./extract-data-from-block')
+
+// Logic to export a single raw block
+module.exports = (cid, node, name, path, pathRest, resolve, size, dag, parent, depth, offset, length) => {
+  const accepts = pathRest[0]
+
+  if (accepts !== undefined && accepts !== path) {
+    return pull.empty()
+  }
+
+  size = size || node.length
+
+  if (offset < 0) {
+    return pull.error(new Error('Offset must be greater than 0'))
+  }
+
+  if (offset > size) {
+    return pull.error(new Error('Offset must be less than the file size'))
+  }
+
+  if (length < 0) {
+    return pull.error(new Error('Length must be greater than or equal to 0'))
+  }
+
+  if (length === 0) {
+    return pull.once({
+      depth,
+      content: pull.once(Buffer.alloc(0)),
+      hash: cid,
+      name,
+      path,
+      size,
+      type: 'raw'
+    })
+  }
+
+  if (!offset) {
+    offset = 0
+  }
+
+  if (!length || (offset + length > size)) {
+    length = size - offset
+  }
+
+  return pull.once({
+    depth,
+    content: pull.once(extractDataFromBlock(node, 0, offset, offset + length)),
+    hash: cid,
+    name,
+    path,
+    size,
+    type: 'raw'
+  })
+}

--- a/test/builder-dir-sharding.js
+++ b/test/builder-dir-sharding.js
@@ -115,7 +115,7 @@ module.exports = (repo) => {
             expect(nodes.length).to.be.eql(2)
             const expectedHash = new CID(shardedHash).toBaseEncodedString()
             expect(nodes[0].path).to.be.eql(expectedHash)
-            expect(nodes[0].hash).to.be.eql(expectedHash)
+            expect(new CID(nodes[0].hash).toBaseEncodedString()).to.be.eql(expectedHash)
             expect(nodes[1].path).to.be.eql(expectedHash + '/b')
             expect(nodes[1].size).to.be.eql(21)
             pull(

--- a/test/importer.js
+++ b/test/importer.js
@@ -219,7 +219,11 @@ module.exports = (repo) => {
       pam: {
         multihash: 'QmPAixYTaYnPe795fcWcuRpo6tfwHgRKNiBHpMzoomDVN6',
         size: 2656553
-      }
+      },
+      '200Bytes.txt with raw leaves': extend({}, baseFiles['200Bytes.txt'], {
+        multihash: 'zb2rhXrz1gkCv8p4nUDZRohY6MzBE9C3HVTVDP72g6Du3SD9Q',
+        size: 200
+      })
     }, strategyOverrides[strategy])
 
     const expected = extend({}, defaultResults, strategies[strategy])
@@ -315,6 +319,21 @@ module.exports = (repo) => {
           pull.collect((err, files) => {
             expect(err).to.not.exist()
             expect(stringifyMh(files)).to.be.eql([expected['200Bytes.txt']])
+            done()
+          })
+        )
+      })
+
+      it('small file (smaller than a chunk) with raw leaves', (done) => {
+        pull(
+          pull.values([{
+            path: '200Bytes.txt',
+            content: pull.values([smallFile])
+          }]),
+          importer(ipld, Object.assign({}, options, { rawLeaves: true })),
+          pull.collect((err, files) => {
+            expect(err).to.not.exist()
+            expect(stringifyMh(files)).to.be.eql([expected['200Bytes.txt with raw leaves']])
             done()
           })
         )


### PR DESCRIPTION
For files smaller than max chunk size and raw leaves true, go-ipfs will create a single node that is a raw buffer. Prior to this PR, js-ipfs created a unixfs file node who's data was the raw buffer. This resulted in different hashes for the same file.

This PR changes the builder to do the same thing as go-ipfs and adds a resolver to the exporter that allows the exporter to export a node that is a single raw buffer (so that you can `ipfs cat [CID w codec raw]` as you can in go-ipfs).

I was going to write an interop test but it's already [here](https://github.com/ipfs/interop/pull/25) and this PR should aid that branch to pass.