### PR TITLE
[WIP] refactor: base32 encoded CID v1 by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "ipfs-unixfs-exporter": "~0.35.4",
-    "ipfs-unixfs-importer": "~0.38.0"
+    "ipfs-unixfs-importer": "github:ipfs/js-ipfs-unixfs-importer#refactor/cidv1b32-default"
   },
   "contributors": [
     "Alan Shaw <alan@tableflip.io>",


### PR DESCRIPTION
BREAKING CHANGE: CIDs created by this module will default to v1 and will be base32 encoded by default.

* [x] depends on https://github.com/ipfs/js-ipfs-unixfs-importer/pull/21